### PR TITLE
ridgepoleの実行をrakeタスクに変更/カラムに制約

### DIFF
--- a/db/Schemafile
+++ b/db/Schemafile
@@ -1,2 +1,17 @@
-require 'categories.schema'
-require 'times.schema'
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  t.bigint "category_id", null: false
+  t.string "name", null: false
+  t.datetime "created_at", null: false
+  t.datetime "updated_at", null: false
+  t.integer "user_id", null: false
+end
+
+create_table "times", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  t.string "time", null: false
+  t.bigint "times_category_id", null: false
+  t.datetime "created_at", null: false
+  t.datetime "updated_at", null: false
+  t.integer "user_id", null: false
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,4 +12,20 @@
 
 ActiveRecord::Schema.define(version: 0) do
 
+  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+  end
+
+  create_table "times", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "time", null: false
+    t.bigint "times_category_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+  end
+
 end

--- a/lib/tasks/ridgepole.rake
+++ b/lib/tasks/ridgepole.rake
@@ -1,0 +1,27 @@
+namespace :ridgepole do
+  desc 'Apply database schema'
+  task apply: :environment do
+    ridgepole('--apply', "--file #{schema_file}")
+    Rake::Task['db:schema:dump'].invoke
+  end
+
+  desc 'Export database schema'
+  task export: :environment do
+    ridgepole('--export', "--output #{schema_file}")
+  end
+
+  private
+
+  def schema_file
+    Rails.root.join('db/Schemafile')
+  end
+
+  def config_file
+    Rails.root.join('config/database.yml')
+  end
+
+  def ridgepole(*options)
+    command = ['bundle exec ridgepole', "--config #{config_file}"]
+    system [command + options].join(' ')
+  end
+end


### PR DESCRIPTION
## なぜ必要か
*作業効率を上げるため
*誤ったデータの挿入を防ぐため

## どういう対応か
*rakeで実行できるスクリプトを作成
*DBにデータ挿入時にNULLで入らないよう制約を設けた

### Front
*

### Server
*

## その他確認したいこと等
* 
